### PR TITLE
update to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       name: Download Release Signed
       with:
         name: ReleaseSigned

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ outputs:
   url: # id of output
     description: 'URl to Partner Dashboard'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'upload-cloud'


### PR DESCRIPTION
Node 12 and Node 16 are deprecated, time to update to Node 20 instead.